### PR TITLE
win32perf

### DIFF
--- a/src/attr.c
+++ b/src/attr.c
@@ -55,7 +55,7 @@ int git_attr_get(
 
 	*value = NULL;
 
-	if (git_attr_path__init(&path, pathname, git_repository_workdir(repo)) < 0)
+	if (git_attr_path__init(&path, pathname, git_repository_workdir(repo), GIT_DIR_FLAG_UNKNOWN) < 0)
 		return -1;
 
 	if ((error = collect_attr_files(repo, NULL, flags, pathname, &files)) < 0)
@@ -114,7 +114,7 @@ int git_attr_get_many_with_session(
 
 	assert(values && repo && names);
 
-	if (git_attr_path__init(&path, pathname, git_repository_workdir(repo)) < 0)
+	if (git_attr_path__init(&path, pathname, git_repository_workdir(repo), GIT_DIR_FLAG_UNKNOWN) < 0)
 		return -1;
 
 	if ((error = collect_attr_files(repo, attr_session, flags, pathname, &files)) < 0)
@@ -193,7 +193,7 @@ int git_attr_foreach(
 
 	assert(repo && callback);
 
-	if (git_attr_path__init(&path, pathname, git_repository_workdir(repo)) < 0)
+	if (git_attr_path__init(&path, pathname, git_repository_workdir(repo), GIT_DIR_FLAG_UNKNOWN) < 0)
 		return -1;
 
 	if ((error = collect_attr_files(repo, NULL, flags, pathname, &files)) < 0 ||

--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -450,7 +450,7 @@ git_attr_assignment *git_attr_rule__lookup_assignment(
 }
 
 int git_attr_path__init(
-	git_attr_path *info, const char *path, const char *base)
+	git_attr_path *info, const char *path, const char *base, git_dir_flag dir_flag)
 {
 	ssize_t root;
 
@@ -481,7 +481,21 @@ int git_attr_path__init(
 	if (!info->basename || !*info->basename)
 		info->basename = info->path;
 
-	info->is_dir = (int)git_path_isdir(info->full.ptr);
+	switch (dir_flag)
+	{
+	case GIT_DIR_FLAG_FALSE:
+		info->is_dir = 0;
+		break;
+
+	case GIT_DIR_FLAG_TRUE:
+		info->is_dir = 1;
+		break;
+
+	case GIT_DIR_FLAG_UNKNOWN:
+	default:
+		info->is_dir = (int)git_path_isdir(info->full.ptr);
+		break;
+	}
 
 	return 0;
 }

--- a/src/attr_file.h
+++ b/src/attr_file.h
@@ -202,8 +202,10 @@ extern bool git_attr_rule__match(
 extern git_attr_assignment *git_attr_rule__lookup_assignment(
 	git_attr_rule *rule, const char *name);
 
+typedef enum { GIT_DIR_FLAG_TRUE = 1, GIT_DIR_FLAG_FALSE = 0, GIT_DIR_FLAG_UNKNOWN = -1 } git_dir_flag;
+
 extern int git_attr_path__init(
-	git_attr_path *info, const char *path, const char *base);
+	git_attr_path *info, const char *path, const char *base, git_dir_flag is_dir);
 
 extern void git_attr_path__free(git_attr_path *info);
 

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -348,7 +348,7 @@ static bool ignore_lookup_in_rules(
 }
 
 int git_ignore__lookup(
-	int *out, git_ignores *ignores, const char *pathname)
+	int *out, git_ignores *ignores, const char *pathname, git_dir_flag dir_flag)
 {
 	unsigned int i;
 	git_attr_file *file;
@@ -357,7 +357,7 @@ int git_ignore__lookup(
 	*out = GIT_IGNORE_NOTFOUND;
 
 	if (git_attr_path__init(
-		&path, pathname, git_repository_workdir(ignores->repo)) < 0)
+		&path, pathname, git_repository_workdir(ignores->repo), dir_flag) < 0)
 		return -1;
 
 	/* first process builtins - success means path was found */
@@ -430,7 +430,7 @@ int git_ignore_path_is_ignored(
 	memset(&path, 0, sizeof(path));
 	memset(&ignores, 0, sizeof(ignores));
 
-	if ((error = git_attr_path__init(&path, pathname, workdir)) < 0 ||
+	if ((error = git_attr_path__init(&path, pathname, workdir, GIT_DIR_FLAG_UNKNOWN)) < 0 ||
 		(error = git_ignore__for_path(repo, path.path, &ignores)) < 0)
 		goto cleanup;
 

--- a/src/ignore.h
+++ b/src/ignore.h
@@ -49,7 +49,7 @@ enum {
 	GIT_IGNORE_TRUE = 1,
 };
 
-extern int git_ignore__lookup(int *out, git_ignores *ign, const char *path);
+extern int git_ignore__lookup(int *out, git_ignores *ign, const char *path, git_dir_flag dir_flag);
 
 /* command line Git sometimes generates an error message if given a
  * pathspec that contains an exact match to an ignored file (provided

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -984,6 +984,21 @@ static void fs_iterator__seek_frame_start(
 		ff->index = 0;
 }
 
+GIT_INLINE(int) path_dirload_with_stat(
+	const char *path,
+	size_t prefix_len,
+	unsigned int flags,
+	const char *start_stat,
+	const char *end_stat,
+	git_vector *contents)
+{
+#if defined(GIT_WIN32) && !defined(__MINGW32__)
+	return	git_win32_path_dirload_with_stat(path, prefix_len, flags, start_stat, end_stat, contents);
+#else
+	return	git_path_dirload_with_stat(path, prefix_len, flags, start_stat, end_stat, contents);
+#endif
+}
+
 static int fs_iterator__expand_dir(fs_iterator *fi)
 {
 	int error;
@@ -998,7 +1013,7 @@ static int fs_iterator__expand_dir(fs_iterator *fi)
 	ff = fs_iterator__alloc_frame(fi);
 	GITERR_CHECK_ALLOC(ff);
 
-	error = git_path_dirload_with_stat(
+	error = path_dirload_with_stat(
 		fi->path.ptr, fi->root_len, fi->dirload_flags,
 		fi->base.start, fi->base.end, &ff->entries);
 
@@ -1350,6 +1365,7 @@ GIT_INLINE(git_dir_flag) git_entry__dir_flag(git_index_entry *entry) {
 		? S_ISDIR(entry->mode) ? GIT_DIR_FLAG_TRUE : GIT_DIR_FLAG_FALSE
 		: GIT_DIR_FLAG_UNKNOWN;
 #else
+	GIT_UNUSED(entry);
 	return GIT_DIR_FLAG_UNKNOWN;
 #endif
 }

--- a/src/win32/path_w32.h
+++ b/src/win32/path_w32.h
@@ -8,6 +8,7 @@
 #define INCLUDE_git_path_w32_h__
 
 #include "common.h"
+#include "vector.h"
 
 /*
  * Provides a large enough buffer to support Windows paths:  MAX_PATH is
@@ -78,5 +79,31 @@ extern int git_win32_path_to_utf8(git_win32_utf8_path dest, const wchar_t *src);
  * @return The name of the shortname for the given path
  */
 extern char *git_win32_path_8dot3_name(const char *path);
+
+#if !defined(__MINGW32__)
+/**
+ * Load all directory entries along with stat info into a vector.
+ * Performed in a single pass per directory for optimized performance on Windows.
+ *
+ * This adds four things on top of plain `git_path_dirload`:
+ *
+ * 1. Each entry in the vector is a `git_path_with_stat` struct that
+ *    contains both the path and the stat info
+ * 2. The entries will be sorted alphabetically
+ * 3. Entries that are directories will be suffixed with a '/'
+ * 4. Optionally, you can be a start and end prefix and only elements
+ *    after the start and before the end (inclusively) will be stat'ed.
+ *
+ * @param path The directory to read from
+ * @param prefix_len The trailing part of path to prefix to entry paths
+ * @param flags GIT_PATH_DIR flags from above
+ * @param start_stat As optimization, only stat values after this prefix
+ * @param end_stat As optimization, only stat values before this prefix
+ * @param contents Vector to fill with git_path_with_stat structures
+ */
+extern int git_win32_path_dirload_with_stat(const char *path, size_t prefix_len, unsigned int flags, const char *start_stat, const char *end_stat, git_vector *contents);
+#endif
+
+extern int git_win32_path_readlink_w(git_win32_path dest, const git_win32_path path);
 
 #endif

--- a/src/win32/posix.h
+++ b/src/win32/posix.h
@@ -49,7 +49,15 @@ extern int p_ftruncate(int fd, git_off_t size);
  */
 extern int p_lstat_posixly(const char *filename, struct stat *buf);
 
-extern struct tm * p_localtime_r (const time_t *timer, struct tm *result);
-extern struct tm * p_gmtime_r (const time_t *timer, struct tm *result);
+extern struct tm * p_localtime_r(const time_t *timer, struct tm *result);
+extern struct tm * p_gmtime_r(const time_t *timer, struct tm *result);
+
+GIT_INLINE(time_t) filetime_to_time_t(const FILETIME *ft)
+{
+	long long winTime = ((long long)ft->dwHighDateTime << 32) + ft->dwLowDateTime;
+	winTime -= 116444736000000000LL; /* Windows to Unix Epoch conversion */
+	winTime /= 10000000;             /* Nano to seconds resolution */
+	return (time_t)winTime;
+}
 
 #endif

--- a/tests/attr/lookup.c
+++ b/tests/attr/lookup.c
@@ -13,7 +13,7 @@ void test_attr_lookup__simple(void)
 	cl_assert_equal_s(cl_fixture("attr/attr0"), file->entry->path);
 	cl_assert(file->rules.length == 1);
 
-	cl_git_pass(git_attr_path__init(&path, "test", NULL));
+	cl_git_pass(git_attr_path__init(&path, "test", NULL, GIT_DIR_FLAG_UNKNOWN));
 	cl_assert_equal_s("test", path.path);
 	cl_assert_equal_s("test", path.basename);
 	cl_assert(!path.is_dir);
@@ -36,7 +36,7 @@ static void run_test_cases(git_attr_file *file, struct attr_expected *cases, int
 	int error;
 
 	for (c = cases; c->path != NULL; c++) {
-		cl_git_pass(git_attr_path__init(&path, c->path, NULL));
+		cl_git_pass(git_attr_path__init(&path, c->path, NULL, GIT_DIR_FLAG_UNKNOWN));
 
 		if (force_dir)
 			path.is_dir = 1;
@@ -133,7 +133,7 @@ void test_attr_lookup__match_variants(void)
 	cl_assert_equal_s(cl_fixture("attr/attr1"), file->entry->path);
 	cl_assert(file->rules.length == 10);
 
-	cl_git_pass(git_attr_path__init(&path, "/testing/for/pat0", NULL));
+	cl_git_pass(git_attr_path__init(&path, "/testing/for/pat0", NULL, GIT_DIR_FLAG_UNKNOWN));
 	cl_assert_equal_s("pat0", path.basename);
 
 	run_test_cases(file, cases, 0);


### PR DESCRIPTION
Improves status on Win32 systems by a rather large margin. Brings libgit2 status on Win32 inline with git.git w/ core.fscache and core.preloadindex enabled.

Some minor code clean up while I was in there to bring various blocks of code inline with the surrounding blocks of code. OCD :-)
